### PR TITLE
add umami site analytics to record per-page stats

### DIFF
--- a/layouts/partials/head-extra.html
+++ b/layouts/partials/head-extra.html
@@ -1,1 +1,2 @@
 <link rel="stylesheet" href="{{ "css/override.css" | absURL }}?rnd={{ now.Unix }}" />
+<script defer src="https://cloud.umami.is/script.js" data-website-id="b721b749-0274-4a80-972d-6f8972fed0db"></script>


### PR DESCRIPTION
Using [umami](https://umami.is) because they respect privacy as much as possible.

Free plan includes 3 sites and up to 100k events per month (which should be plenty)

Will need to move the account email/password to something accessible/shared by the team, but that will happen off-github.