### PR TITLE
Change map on site to api.phillymesh.net

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -14,7 +14,7 @@ If you are interested in learning more about Meshtastic and LoRa check out our [
 
 If you are interested in helping support PhillyMesh and Philly Radio & Meshtastic, please consider using our [affiliate link at Rokland when you purchase Meshtastic hardware](https://store.rokland.com/?ref=phillymesh).
 
-<iframe src="https://api.phillymesh.net/map" width="100%" height="500"></iframe>
+<iframe src="https://api.phillymesh.net/map" width="100%" height="900"></iframe>
 
 ---
 


### PR DESCRIPTION
PR to change map from meshtastic.liamcottle.net to our own api.phillymesh.net. Avoids relying on a third party embed and external advertising.

I did not see a built-in Malla option for embed or minimal mode, so I adjusted iframe dimensions to give the map more usable space. If a cleaner embed is wanted long term, perhaps there's an option to add an embed mode to the API?
