### PR TITLE
Quick update of existing guides

### DIFF
--- a/content/freq-test-instructions.md
+++ b/content/freq-test-instructions.md
@@ -16,13 +16,13 @@ type: page
 
 ~~**Saturday, 8/8/26 at 10pm**: switch nodes to LongTurbo slot 12~~ **Concluded**
 
-~~**Saturday, 8/14/26 at 10pm**: switch nodes back to LongFast 20 and tune into the discussion of the result in the [PhillyMesh Discord](https://discord.phlm.sh).~~ Postponed
+~~**Saturday, 8/14/26 at 10pm**: switch nodes back to LongFast 20 and tune into the discussion of the result in the [PhillyMesh Discord](https://discord.phlm.sh).~~ **Postponed**
 
-**Wednesday, 8/12/26**: Testing Pivoted to a 3rd test based on new findings from the first two tests. Deeper analysis of the regional noise many members experienced was investigated by members using a Software Defined Radio (SDR). 
+**Wednesday, 8/12/26**: Testing pivoted to a 3rd test based on new findings from the first two tests. Deeper analysis of the regional noise many members experienced was investigated by members using a software-defined radio (SDR). 
 
-This new extended test is being referred to as LongFast 910 or LF910 for short. It is slightly different than the previous tests in that you are not selecting a custom frequency slot, but a custom frequency override!. 
+This new extended test is being referred to as LongFast 910 or LF910 for short. It is slightly different than the previous tests in that you are not selecting a custom frequency slot, but a custom frequency override! 
 
-This override allows us to slide between the bands of noise and RFID interference we've discovered and have clearer communications! Preliminary testing has gone so well in fact that we've moved this phase to **extended testing** with no specified end date at this time!
+This override allows us to slide between the bands of noise and RFID interference we've discovered and have clearer communications! Preliminary testing has gone so well, in fact, that we've moved this phase to **extended testing** with no specified end date at this time!
 
 # Full Instructions
 

--- a/content/freq-test-instructions.md
+++ b/content/freq-test-instructions.md
@@ -12,13 +12,17 @@ type: page
 
 ## Test Timeline
 
-~~**Saturday, 8/1/26 at 10pm**: switch nodes to MediumSlow slot 22~~ Concluded
+~~**Saturday, 8/1/26 at 10pm**: switch nodes to MediumSlow slot 22~~ **Concluded**
 
-~~**Saturday, 8/8/26 at 10pm**: switch nodes to LongTurbo slot 12~~
+~~**Saturday, 8/8/26 at 10pm**: switch nodes to LongTurbo slot 12~~ **Concluded**
 
 ~~**Saturday, 8/14/26 at 10pm**: switch nodes back to LongFast 20 and tune into the discussion of the result in the [PhillyMesh Discord](https://discord.phlm.sh).~~ Postponed
 
-**Wednesday, 8/12/26**: Testing Pivoted to a 3rd test based on new findings from the first two tests. Deeper analysis of the regional noise may members experienced was investigated by members with Software Defined Radios. This new extended test is being referred to as LongFast 910 or LF910 for short. It is slightly different than the previous tests in that you are not just selecting a custom frequency slot, but a custom frequency override. This override allows us to slide between the bands of noise and RFID interference we've discovered and have clearer communications! Preliminary testing has gone so well in fact that we've moved this phase to **extended testing** with no specified end date at this time!
+**Wednesday, 8/12/26**: Testing Pivoted to a 3rd test based on new findings from the first two tests. Deeper analysis of the regional noise many members experienced was investigated by members using a Software Defined Radio (SDR). 
+
+This new extended test is being referred to as LongFast 910 or LF910 for short. It is slightly different than the previous tests in that you are not selecting a custom frequency slot, but a custom frequency override!. 
+
+This override allows us to slide between the bands of noise and RFID interference we've discovered and have clearer communications! Preliminary testing has gone so well in fact that we've moved this phase to **extended testing** with no specified end date at this time!
 
 # Full Instructions
 

--- a/content/freq-test-instructions.md
+++ b/content/freq-test-instructions.md
@@ -12,11 +12,13 @@ type: page
 
 ## Test Timeline
 
-**Saturday, 8/1/26 at 10pm**: switch nodes to MediumSlow slot 22
+~~**Saturday, 8/1/26 at 10pm**: switch nodes to MediumSlow slot 22~~ Concluded
 
-**Saturday, 8/8/26 at 10pm**: switch nodes to LongTurbo slot 12
+~~**Saturday, 8/8/26 at 10pm**: switch nodes to LongTurbo slot 12~~
 
-**Saturday, 8/14/26 at 10pm**: switch nodes back to LongFast 20 and tune into the discussion of the result in the [PhillyMesh Discord](https://discord.phlm.sh).
+~~**Saturday, 8/14/26 at 10pm**: switch nodes back to LongFast 20 and tune into the discussion of the result in the [PhillyMesh Discord](https://discord.phlm.sh).~~ Postponed
+
+**Wednesday, 8/12/26**: Testing Pivoted to a 3rd test based on new findings from the first two tests. Deeper analysis of the regional noise may members experienced was investigated by members with Software Defined Radios. This new extended test is being referred to as LongFast 910 or LF910 for short. It is slightly different than the previous tests in that you are not just selecting a custom frequency slot, but a custom frequency override. This override allows us to slide between the bands of noise and RFID interference we've discovered and have clearer communications! Preliminary testing has gone so well in fact that we've moved this phase to **extended testing** with no specified end date at this time!
 
 # Full Instructions
 
@@ -42,7 +44,7 @@ If your node doesn't support newer firmware or flashing on the webpage and you n
 
 | Setting Name | Base/Stationary Node | Mobile Node | Notes |
 | ----- | ---- | ---- | ---- |
-| `Preset` | MediumSlow Slot 22 or LongTurbo Slot 12 depending on the test week. | MediumSlow Slot 22 or LongTurbo Slot 12 depending on the test week. | Set Default Hops to `3`. If you are way out in the burbs or a rural area, you can bump this up to `4` or even `5`. Going up to `6` and higher is never needed and is harmful to the mesh. |
+| `Preset` | LongFast with a frequency override of 910 | LongFast with a frequency override of 910 | Set Default Hops to `3`. If you are way out in the burbs or a rural area, you can bump this up to `4` or even `5`. Going up to `6` and higher is never needed and is harmful to the mesh. |
 | `Device Role` | (Choose one of the following:) `Client`, `Client_Base`, `Client_Mute` | (Choose one of the following:) `Client`, `Client_Mute` | T-1000e and Wismesh Tag (or any mobile node without an external antenna) should always be `client_mute`. Do not use anything other than these roles without consulting the PhillyMesh Discord. The other roles are usually harmful to the mesh without any benefit to you. |
 | `Rebroadcast Mode` | `core_portnums_only` | `core_portnums_only` | `All` is the default, which works, but this setting eliminates non-standard packets such as Range Tests from being rebroadcast. This can help reduce congestion from improperly set-up or rudely operating nodes. |
 | `NodeInfo Broadcast Interval` | `>= 12 Hours` | `>= 12 Hours` | Can be longer than 12 hours, but not shorter. |

--- a/content/freq-test.md
+++ b/content/freq-test.md
@@ -15,7 +15,7 @@ On Saturday, August 1st at 10pm a group of organized Philadelphia Mesh users wil
 
 ~~Test 2: Aug 8th at 10pm to Aug 14th at 10pm we will be testing LongTurbo 12~~ Concluded
 
-Extended Test 3: On Aug 11th we pivoted to a 3rd test based on preliminary data of the first two tests and deeper analysis of the regional noise many members discovered across the bands. This new extended test is being referred to as LongFast 910 or LF910 for short, and shows great promise!
+Extended Test 3: On Aug 12th we pivoted to a 3rd test based on preliminary data of the first two tests and deeper analysis of the regional noise many members discovered across the bands. This new extended test is being referred to as LongFast 910 or LF910 for short, and shows great promise!
 
 In addition to the different preset and non-default frequency slot, there are some other settings you're required to change if you want to participate in this test. [Please view the full instructions with screenshots here](/freq-test-instructions/) to participate.
 

--- a/content/freq-test.md
+++ b/content/freq-test.md
@@ -11,9 +11,11 @@ This is a primer on why we will be testing different Meshtastic frequencies and 
 
 On Saturday, August 1st at 10pm a group of organized Philadelphia Mesh users will be switching from the default frequency preset to a custom one to test if custom presets are more reliable than the default. We welcome you to join in on our test and help us improve the Philly Mesh!
 
-Test 1: Aug 1st at 10pm to Aug 8th at 10pm we will be testing MediumSlow 22
+~~Test 1: Aug 1st at 10pm to Aug 8th at 10pm we will be testing MediumSlow 22~~ Concluded
 
-Test 2: Aug 8th at 10pm to Aug 14th at 10pm we will be testing LongTurbo 12
+~~Test 2: Aug 8th at 10pm to Aug 14th at 10pm we will be testing LongTurbo 12~~ Concluded
+
+Extended Test 3: On Aug 11th we pivoted to a 3rd test based on preliminary data of the first two tests and deeper analysis of the regional noise many members discovered across the bands. This new extended test is being referred to as LongFast 910 or LF910 for short, and shows great promise!
 
 In addition to the different preset and non-default frequency slot, there are some other settings you're required to change if you want to participate in this test. [Please view the full instructions with screenshots here](/freq-test-instructions/) to participate.
 

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
         "Phlm.sh",
         "Pico",
         "Rokland",
+        "RFID",
         "RSSI",
         "Seeed",
         "SUSQ",


### PR DESCRIPTION
Quick update of existing guides to align with current testing path. this allows us to point to current guide for members that want to join LF910, without linking guide and then telling them the additional steps manually on discord.

this is to hold us over till full article results are collected and published.